### PR TITLE
Only execute systemd handlers when systemd is set.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,10 @@
 - name: Reload Systemd
   systemd:
     daemon_reload: yes
+  when: gie_proxy_setup_service == "systemd"
 
 - name: Restart GIE Proxy
   service:
     name: "{{ gie_proxy_service_name }}"
     state: restarted
+  when: gie_proxy_setup_service == "systemd"


### PR DESCRIPTION
This addresses #2 when trying to use the role with a different process manager.