### PR TITLE
Fix typos + update repo url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 #gie_proxy_sessions_path:
 
 # optional:
-gie_proxy_git_repo: https://github.com/usegalaxy-eu/gie-nodejs-proxy
+gie_proxy_git_repo: https://github.com/galaxyproject/gx-it-proxy
 #gie_proxy_git_version:
 #gie_proxy_npm_executable:
 #gie_proxy_nodejs_executable:

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -12,8 +12,8 @@
       pip:
         name: nodeenv
         virtualenv: "{{ gie_proxy_virtualenv }}"
-        virtualenv_command: "{{ gie_proxy_virtulenv_command |default(omit) }}"
-        virtualenv_python: "{{ gie_proxy_virtulenv_python |default(omit) }}"
+        virtualenv_command: "{{ gie_proxy_virtualenv_command |default(omit) }}"
+        virtualenv_python: "{{ gie_proxy_virtualenv_python |default(omit) }}"
 
     - name: Add virtualenv to $PATH
       set_fact:


### PR DESCRIPTION
A little PR to update the git repo url + fix typos in variable names
Fixing the typos will break compatibility for people using the old names, but it's confusing to keep them as is, so... I can update the gtn tutorial if this PR is merged