### PR TITLE
Install gie-proxy only when needed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,5 @@ gie_proxy_nodejs_package: nodejs
 #gie_proxy_nodejs_version:
 #gie_proxy_virtualenv_command:
 #gie_proxy_virtualenv_python:
+
+gie_proxy_install: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     version: "{{ gie_proxy_git_version |default(omit) }}"
   notify:
     - Restart GIE Proxy
+  when: gie_proxy_install
 
 - name: Install Node.js modules
   npm:
@@ -19,6 +20,7 @@
     unsafe_perm: "{{ gie_proxy_npm_unsafe_perm |default(omit) }}"
   environment:
     PATH: "{{ ansible_path |default(ansible_env.PATH) }}"
+  when: gie_proxy_install
 
 - name: Include Service setup tasks
   include_tasks: service.yml


### PR DESCRIPTION
The new variable is `gie_proxy_install` _(defaults to `true`)_. Through this variable, we can decide whether to install (tasks: clone the gx-it-proxy repo and compile the Node JS modules) or not. We (at EU) only want this to be installed on the maintenance node without the systemd service and then on the head node(s), we would need only the systemd service (because at EU, we plan to have 2 head nodes in the near future, so we will have Galaxy installed on one node and then sync it to NFS and from there to the head node(s)). So with this new variable, we can switch them ON and OFF depending on where we are installing. This variable will not affect the current behaviour (_the default value is set to `true`_). Other tasks in the playbook already contain variables, so we can use them to switch things ON and OFF.