### PR TITLE
Remove notify from include tasks and add new tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,8 @@
   systemd:
     daemon_reload: yes
 
-- name: Restart GIE Proxy
+- name: Start and enable GIE Proxy
   service:
     name: "{{ gie_proxy_service_name }}"
-    state: restarted
+    state: started
+    enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,4 @@
 
 - name: Include Service setup tasks
   include_tasks: service.yml
-  notify:
-    - Restart GIE Proxy
   when: gie_proxy_setup_service is not none

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -9,7 +9,13 @@
         dest: "/etc/systemd/system/{{ gie_proxy_service_name }}.service"
       notify:
         - Reload Systemd
-        - Restart GIE Proxy
+        - Start and enable GIE Proxy
+
+    # Need an exclusive restart here in cases when the service file does not get udpated but the code does
+    - name: Restart GIE Proxy
+      service:
+        name: "{{ gie_proxy_service_name }}"
+        state: restarted
 
     - name: Flush handlers
       meta: flush_handlers


### PR DESCRIPTION
`notify` in `include` breaks the role from running (silly mistake)