### PR TITLE
Support configuring the `--proxyPathPrefix` command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Including an example of how to use your role (for instance, with variables passe
     gie_proxy_nodejs_version: "10.13.0"
     gie_proxy_virtualenv: /srv/gie-proxy/venv
     gie_proxy_setup_service: systemd
+    # configuring this path prefix enables path-based interactive tools
+    # (https://docs.galaxyproject.org/en/master/admin/special_topics/interactivetools.html#nginx-proxy-server-configuration-in-production)
+    gie_proxy_path_prefix: /interactivetool/ep  
     gie_proxy_port: 4002
     gie_proxy_verbose: true
     gie_proxy_sessions_path: "/srv/galaxy/var/data/interactivetools_map.sqlite"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,13 +14,14 @@ gie_proxy_user: galaxy
 gie_proxy_group: galaxy
 
 gie_proxy_ip: 127.0.0.1
+gie_proxy_path_prefix: null
 gie_proxy_port: 8000
 gie_proxy_verbose: null
 
 gie_proxy_command_line: >-
     {{ gie_proxy_nodejs_executable |default(gie_proxy_virtualenv ~ '/bin/node' if gie_proxy_virtualenv is defined else 'node') }}
     {{ gie_proxy_dir }}/lib/main.js --ip {{ gie_proxy_ip }} --port {{ gie_proxy_port }} --sessions {{ gie_proxy_sessions_path }}
-    {{ '--verbose' if gie_proxy_verbose else '' }}
+    {{ '--verbose' if gie_proxy_verbose else '' }} {{ '--proxyPathPrefix ' + gie_proxy_path_prefix if gie_proxy_path_prefix != None else '' }}
 
 # options: "package", "nodeenv"
 gie_proxy_setup_nodejs: null


### PR DESCRIPTION
Add the `gie_proxy_path_prefix` configuration variable. It allows to call the proxy with the  `--proxyPathPrefix` command line argument. By default it is null, which means the argument is not appended to the command that calls the proxy.