### PR TITLE
Dependencies for PostgreSQL support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,4 +40,17 @@ gie_proxy_nodejs_package: nodejs
 #gie_proxy_virtualenv_command:
 #gie_proxy_virtualenv_python:
 
+# install `libpq` to build `pg-native`, a nodejs package required to use the
+# interactive tools proxy with PostgreSQL
+gie_proxy_setup_libpq: |-
+  {{
+      {
+        'RedHat': true,
+        'Other': false,
+      }[ansible_facts.os_family | default('Other')]
+  }} and gie_proxy_install
+
 gie_proxy_install: true
+
+# enable PostgreSQL support (install `pg-native` npm package)
+gie_proxy_install_pgnative: gie_proxy_install and gie_proxy_setup_libpq

--- a/tasks/libpq.yml
+++ b/tasks/libpq.yml
@@ -1,0 +1,20 @@
+- name: Error out when the platform is unsupported
+  ansible.builtin.fail:
+    msg: "Cannot install `libpq`, OS family {{ ansible_facts['os_family'] }} unsupported"
+  when: "ansible_facts['os_family'] not in ['RedHat']"
+
+- name: Install `libpq` and build tools (RedHat)
+  # needed to build the npm package `pg-native`, an optional dependency of the
+  # interactive tools proxy
+  become: true
+  ansible.builtin.package:
+    name:
+      - libpq
+      - libpq-devel
+      - make
+      - glibc
+      - gcc-c++
+      - which
+      - redhat-rpm-config
+    state: present
+  when: "'RedHat' in ansible_facts['os_family']"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,14 +11,31 @@
     version: "{{ gie_proxy_git_version |default(omit) }}"
   when: gie_proxy_install
 
+- name: Install `libpq` and build tools
+  # used to build `pg-native` from the npm registry,
+  # needed make the GIE Proxy work with PostgreSQL
+  include_tasks: libpq.yml
+  when: gie_proxy_setup_libpq
+
 - name: Install Node.js modules
   npm:
     path: "{{ gie_proxy_dir }}"
     executable: "{{ gie_proxy_npm_executable |default(omit) }}"
     unsafe_perm: "{{ gie_proxy_npm_unsafe_perm |default(omit) }}"
+    no_optional: true
   environment:
     PATH: "{{ ansible_path |default(ansible_env.PATH) }}"
   when: gie_proxy_install
+
+- name: Install `pg-native` Node.js module
+  npm:
+    name: pg-native
+    path: "{{ gie_proxy_dir }}"
+    executable: "{{ gie_proxy_npm_executable |default(omit) }}"
+    unsafe_perm: "{{ gie_proxy_npm_unsafe_perm |default(omit) }}"
+  environment:
+    PATH: "{{ ansible_path |default(ansible_env.PATH) }}"
+  when: gie_proxy_install_pgnative  
 
 - name: Include Service setup tasks
   include_tasks: service.yml


### PR DESCRIPTION
Add configuration options and a tasks file to install the dependencies required for the proxy to work with PostgreSQL. The new settings default to installing them on supported OS families (only RedHat as of now).