### PR TITLE
Discard modified source files when updating the GIE Proxy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
     dest: "{{ gie_proxy_dir }}"
     repo: "{{ gie_proxy_git_repo }}"
     version: "{{ gie_proxy_git_version |default(omit) }}"
+    force: true
   when: gie_proxy_install
 
 - name: Install `libpq` and build tools


### PR DESCRIPTION
When updating the GIE Proxy from Git, discard existing changes to the source files in `gie_proxy_dir`. Fixes the error below.

```
TASK [usegalaxy_eu.gie_proxy : Install GIE Proxy] ******************************
fatal: [sn06.galaxyproject.eu]: FAILED! => {"before": "21ce7fea3139615be9e3b71da58d5f6681af454d", "changed": false, "msg": "Local modifications exist in the destination: /opt/galaxy/gie-proxy/proxy (force=no)."}
```