### PR TITLE
Flush handlers before restarting the GIE Proxy

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -11,14 +11,14 @@
         - Reload Systemd
         - Start and enable GIE Proxy
 
+    - name: Flush handlers
+      meta: flush_handlers
+
     # Need an exclusive restart here in cases when the service file does not get udpated but the code does
     - name: Restart GIE Proxy
       service:
         name: "{{ gie_proxy_service_name }}"
         state: restarted
-
-    - name: Flush handlers
-      meta: flush_handlers
 
     - name: Ensure GIE Proxy service is enabled and running
       service:


### PR DESCRIPTION
If the service unit changes, the handler "Reload Systemd" needs to run before the task "Restart GIE Proxy", otherwise changes are not picked up by the restart.

As an example, the [log from job #2252](https://build.galaxyproject.eu/job/usegalaxy-eu/job/playbooks/job/sn06/2252/console) shows that the service unit changed, but the task "Restart GIE Proxy" ran before the handler "Reload Systemd". Interactive tools did not work until after running `systemctl daemon-reload && systemctl restart galaxy-gie-proxy.service`.

```
TASK [usegalaxy_eu.gie_proxy : Install Systemd service unit] *******************
--- before: /etc/systemd/system/galaxy-gie-proxy.service
+++ after: /home/centos/.ansible/tmp/ansible-local-6505100ygu2b16/tmp1lsbhggw/gie-proxy.service.j2
@@ -9,7 +9,7 @@
 User=galaxy
 Group=galaxy
 
-ExecStart=/opt/galaxy/gie-proxy/venv/bin/node /opt/galaxy/gie-proxy/proxy/lib/main.js --ip 127.0.0.1 --port 8800 --sessions /opt/galaxy/mutable-data/interactivetools_map.sqlite --verbose --proxyPathPrefix /interactivetool/ep
+ExecStart=/opt/galaxy/gie-proxy/venv/bin/node /opt/galaxy/gie-proxy/proxy/lib/main.js --ip 127.0.0.1 --port 8800 --sessions postgresql://****:****@****.galaxyproject.eu/gxitproxy --verbose --proxyPathPrefix /interactivetool/ep
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT

changed: [sn06.galaxyproject.eu]

TASK [usegalaxy_eu.gie_proxy : Restart GIE Proxy] ******************************
changed: [sn06.galaxyproject.eu]

TASK [usegalaxy_eu.gie_proxy : Flush handlers] *********************************

RUNNING HANDLER [galaxyproject.galaxy : galaxy mule restart] *******************
skipping: [sn06.galaxyproject.eu]

...

RUNNING HANDLER [galaxyproject.galaxy : galaxy gravity restart] ****************
skipping: [sn06.galaxyproject.eu]

RUNNING HANDLER [usegalaxy_eu.gie_proxy : Reload Systemd] **********************
ok: [sn06.galaxyproject.eu]

RUNNING HANDLER [usegalaxy_eu.gie_proxy : Start and enable GIE Proxy] **********
ok: [sn06.galaxyproject.eu]

RUNNING HANDLER [Restart Galaxy] ***********************************************
changed: [sn06.galaxyproject.eu]

TASK [usegalaxy_eu.gie_proxy : Ensure GIE Proxy service is enabled and running] ***
ok: [sn06.galaxyproject.eu]

TASK [usegalaxy_eu.fs_maintenance : check if fsm_maintenance_dir exists] *******
ok: [sn06.galaxyproject.eu]

...
```