### PR TITLE
Make service restart mode and interval before restarts configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ gie_proxy_git_repo: https://github.com/galaxyproject/gx-it-proxy
 #gie_proxy_npm_executable:
 #gie_proxy_nodejs_executable:
 gie_proxy_service_name: galaxy-gie-proxy
+gie_proxy_service_restart_mode: on-failure
+gie_proxy_service_restartsec: 1s
 gie_proxy_user: galaxy
 gie_proxy_group: galaxy
 

--- a/templates/gie-proxy.service.j2
+++ b/templates/gie-proxy.service.j2
@@ -14,8 +14,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT
 
-Restart=on-failure
-RestartSec=1s
+Restart={{ gie_proxy_service_restart_mode }}
+RestartSec={{ gie_proxy_service_restartsec }}
  
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add two variables `gie_proxy_service_restart_mode` and `gie_proxy_service_restartsec` to configure the value of `Restart` and `RestartSec` under the `[Service]` section of the systemd unit file. Their default values match those on the old template file (`on-failure` and `RestartSec`).